### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/EconomyJob/src/onebone/economyjob/EconomyJob.php
+++ b/EconomyJob/src/onebone/economyjob/EconomyJob.php
@@ -48,7 +48,9 @@ class EconomyJob extends PluginBase implements Listener{
 			$this->getLogger()->debug("Tried to load unknown resource ".TextFormat::AQUA.$res.TextFormat::RESET);
 			return false;
 		}
-		return fread($resource, filesize($path));
+		$content = stream_get_contents($resource);
+		@fclose($content);
+		return $content;
 	}
 
 	public function onDisable(){

--- a/EconomyProperty/src/onebone/economyproperty/EconomyProperty.php
+++ b/EconomyProperty/src/onebone/economyproperty/EconomyProperty.php
@@ -42,10 +42,13 @@ class EconomyProperty extends PluginBase implements Listener{
 	private $command;
 
 	public function onEnable(){
-		@mkdir($this->getDataFolder());
+		if(!file_exists($this->getDataFolder())){
+			mkdir($this->getDataFolder());
+		}
 
 		$this->property = new \SQLite3($this->getDataFolder()."Property.sqlite3");
-		$this->property->exec(stream_get_contents($this->getResource("sqlite3.sql")));
+		$this->property->exec(stream_get_contents($resource = $this->getResource("sqlite3.sql")));
+		@fclose($resource);
 		$this->parseOldData();
 
 		$this->getServer()->getPluginManager()->registerEvents($this, $this);


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:

* `Plugin->getResource()` without `fclose()` calls later
* Not needed `Plugin->getResource()` calls
* `fopen()` calls without `fclose()`
* `popen()` calls without `pclose()`