### PR TITLE
Fixed typo(?)

### DIFF
--- a/EconomyAPI/src/onebone/economyapi/EconomyAPI.php
+++ b/EconomyAPI/src/onebone/economyapi/EconomyAPI.php
@@ -88,7 +88,7 @@ class EconomyAPI extends PluginBase implements Listener{
 		"it" => "Italiano",
 		"ch" => "中文",
 		"id" => "Bahasa Indonesia",
-		"user-define" => "User Define"
+		"user-define" => "User Defined"
 	);
 
 	public static function getInstance(){


### PR DESCRIPTION
I think you should also set the $langList key to 'user-defined', but I didn't do that because it possibly break backward-compatibility.