### PR TITLE
Update EconomyLand.php

### DIFF
--- a/EconomyLand/src/onebone/economyland/EconomyLand.php
+++ b/EconomyLand/src/onebone/economyland/EconomyLand.php
@@ -438,7 +438,7 @@ class EconomyLand extends PluginBase implements Listener{
 						$sender->sendMessage($this->getMessage("not-your-land", array($landnum, "%2", "%3")));
 						return true;
 					}elseif(substr($player, 0, 2) === "r:"){
-						if(!$sender->hasPermission("economyland.command.land.invite.remove")){
+						if(!$sender->hasPermission("economyland.command.land.invite")){
 							$sender->sendMessage("You don't have permissions to use this command.");
 							return true;
 						}


### PR DESCRIPTION
The land's owner can use "land invite player",but cannot use "land invite r:player". When a land's owner input this commond (land invite r:plaery) it will show  "You don't have permissions to use this command." . So i think change this permission can temporary solve this bug.