### PR TITLE
Fix a bug when position < 0

### DIFF
--- a/EconomyLand/src/onebone/economyland/EconomyLand.php
+++ b/EconomyLand/src/onebone/economyland/EconomyLand.php
@@ -155,8 +155,8 @@ class EconomyLand extends PluginBase implements Listener{
 				$sender->sendMessage($this->getMessage("run-cmd-in-game"));
 				return true;
 			}
-			$x = (int) $sender->x;
-			$z = (int) $sender->z;
+			$x = floor($sender->x);
+			$z = floor($sender->z);
 			$level = $sender->getLevel()->getFolderName();
 			$this->start[$sender->getName()] = array("x" => $x, "z" => $z, "level" => $level);
 			$sender->sendMessage($this->getMessage("first-position-saved"));
@@ -177,8 +177,8 @@ class EconomyLand extends PluginBase implements Listener{
 
 			$startX = $this->start[$sender->getName()]["x"];
 			$startZ = $this->start[$sender->getName()]["z"];
-			$endX = (int) $sender->x;
-			$endZ = (int) $sender->z;
+			$endX = floor($sender->x);
+			$endZ = floor($sender->z);
 			$this->end[$sender->getName()] = array(
 				"x" => $endX,
 				"z" => $endZ
@@ -235,10 +235,10 @@ class EconomyLand extends PluginBase implements Listener{
 				}
 				$l = $this->start[$sender->getName()];
 				$endp = $this->end[$sender->getName()];
-				$startX = (int) $l["x"];
-				$endX = (int) $endp["x"];
-				$startZ = (int) $l["z"];
-				$endZ = (int) $endp["z"];
+				$startX = floor($l["x"]);
+				$endX = floor($endp["x"]);
+				$startZ = floor($l["z"]);
+				$endZ = floor($endp["z"]);
 				if($startX > $endX){
 					$backup = $startX;
 					$startX = $endX;

--- a/EconomyLand/src/onebone/economyland/database/YamlDatabase.php
+++ b/EconomyLand/src/onebone/economyland/database/YamlDatabase.php
@@ -79,8 +79,8 @@ class YamlDatabase implements Database{
 		if($level instanceof Level){
 			$level = $level->getFolderName();
 		}
-		$x=(int)$x;
-		$z=(int)$z;
+		$x=floor($x);
+		$z=floor($z);
 		foreach($this->land as $land){
 			if($level === $land["level"] and $land["startX"] <= $x and $land["endX"] >= $x and $land["startZ"] <= $z and $land["endZ"] >= $z){
 				return $land;


### PR DESCRIPTION
Fix a bug when position < 0
startp
endp
I am really sorry for this. 
int(1.5) = 1 int(0.5)=0 int(-0.5)=0 int(-1.5)=-1
floor(1.5) = 1 floor(0.5) = 0 floor(-0.5) = -1 floor(-1.5) = -2
and PocketMine only have one '0'. 
So it caused a really big problem when players select the position acrossing 0.
Sorry again.
dog194 committed a minute ago