### PR TITLE
Once again changed usage for "/land kick"

### DIFF
--- a/EconomyLand/src/onebone/economyland/EconomyLand.php
+++ b/EconomyLand/src/onebone/economyland/EconomyLand.php
@@ -468,7 +468,7 @@ class EconomyLand extends PluginBase implements Listener{
 					$player = array_shift($param);
 
 					if(trim($player) === ""){
-						$sender->sendMessage(TextFormat::RED . "Usage: " . $cmd->getUsage());
+						$sender->sendMessage("Usage: /land kick <land number> <player>");
 						return true;
 					}
 					if(!is_numeric($landnum)){


### PR DESCRIPTION
Otherwise "/land kick" would only show the usage for "/land" without sub command. 
Sorry that I didn't see that when I created my previous PR.